### PR TITLE
Move active DFP packs to cmsis_packs/Infineon.pidx, deprecate PSoC6_DFP/PSoC4_DFP/PMG1_DFP

### DIFF
--- a/Cypress.pidx
+++ b/Cypress.pidx
@@ -2,11 +2,11 @@
 <index schemaVersion="1.0.0" xs:noNamespaceSchemaLocation="PackIndex.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance">
   <vendor>Cypress</vendor>
   <url>https://github.com/Infineon/cmsis-packs/raw/master/</url>
-  <timestamp>2024-09-23T13:11:31+00:00</timestamp>
+  <timestamp>2024-11-06T14:57:31+00:00</timestamp>
   <pindex>
-    <pdsc url="https://github.com/Infineon/cmsis-packs/raw/master/PSoC6_DFP/" vendor="Cypress" name="PSoC6_DFP" version="1.2.0"/>
-    <pdsc url="https://github.com/Infineon/cmsis-packs/raw/master/PSoC4_DFP/" vendor="Cypress" name="PSoC4_DFP" version="1.1.0"/>
-    <pdsc url="https://github.com/Infineon/cmsis-packs/raw/master/PMG1_DFP/" vendor="Cypress" name="PMG1_DFP" version="1.0.0"/>
-    <pdsc url="https://github.com/Infineon/cmsis-packs/raw/master/PSoC6_DFP/" vendor="Infineon" name="PSoC6_DFP" version="1.4.0"/>
+    <pdsc url="https://github.com/Infineon/cmsis-packs/raw/master/PSoC6_DFP/" vendor="Cypress" name="PSoC6_DFP" version="1.2.0" deprecated="2024-11-06" replacement="Infineon.CAT1A_DFP" />
+    <pdsc url="https://github.com/Infineon/cmsis-packs/raw/master/PSoC4_DFP/" vendor="Cypress" name="PSoC4_DFP" version="1.1.0" deprecated="2024-11-06" replacement="Infineon.CAT2_DFP" />
+    <pdsc url="https://github.com/Infineon/cmsis-packs/raw/master/PMG1_DFP/" vendor="Cypress" name="PMG1_DFP" version="1.0.0" deprecated="2024-11-06" replacement="Infineon.CAT2_DFP" />
+    <pdsc url="https://github.com/Infineon/cmsis-packs/raw/master/PSoC6_DFP/" vendor="Infineon" name="PSoC6_DFP" version="1.4.0" deprecated="2024-11-06" replacement="Infineon.CAT1A_DFP" />
   </pindex>
 </index>

--- a/Cypress.pidx
+++ b/Cypress.pidx
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <index schemaVersion="1.0.0" xs:noNamespaceSchemaLocation="PackIndex.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance">
   <vendor>Cypress</vendor>
-  <url>https://github.com/cypresssemiconductorco/cmsis-packs/raw/master/</url>
+  <url>https://github.com/Infineon/cmsis-packs/raw/master/</url>
   <timestamp>2024-09-23T13:11:31+00:00</timestamp>
   <pindex>
-    <pdsc url="https://github.com/cypresssemiconductorco/cmsis-packs/raw/master/PSoC6_DFP/" vendor="Cypress" name="PSoC6_DFP" version="1.2.0"/>
-    <pdsc url="https://github.com/cypresssemiconductorco/cmsis-packs/raw/master/PSoC4_DFP/" vendor="Cypress" name="PSoC4_DFP" version="1.1.0"/>
-    <pdsc url="https://github.com/cypresssemiconductorco/cmsis-packs/raw/master/PMG1_DFP/" vendor="Cypress" name="PMG1_DFP" version="1.0.0"/>
+    <pdsc url="https://github.com/Infineon/cmsis-packs/raw/master/PSoC6_DFP/" vendor="Cypress" name="PSoC6_DFP" version="1.2.0"/>
+    <pdsc url="https://github.com/Infineon/cmsis-packs/raw/master/PSoC4_DFP/" vendor="Cypress" name="PSoC4_DFP" version="1.1.0"/>
+    <pdsc url="https://github.com/Infineon/cmsis-packs/raw/master/PMG1_DFP/" vendor="Cypress" name="PMG1_DFP" version="1.0.0"/>
     <pdsc url="https://github.com/Infineon/cmsis-packs/raw/master/PSoC6_DFP/" vendor="Infineon" name="PSoC6_DFP" version="1.4.0"/>
   </pindex>
 </index>

--- a/Cypress.pidx
+++ b/Cypress.pidx
@@ -7,10 +7,6 @@
     <pdsc url="https://github.com/cypresssemiconductorco/cmsis-packs/raw/master/PSoC6_DFP/" vendor="Cypress" name="PSoC6_DFP" version="1.2.0"/>
     <pdsc url="https://github.com/cypresssemiconductorco/cmsis-packs/raw/master/PSoC4_DFP/" vendor="Cypress" name="PSoC4_DFP" version="1.1.0"/>
     <pdsc url="https://github.com/cypresssemiconductorco/cmsis-packs/raw/master/PMG1_DFP/" vendor="Cypress" name="PMG1_DFP" version="1.0.0"/>
-    <pdsc url="https://github.com/Infineon/cmsis-packs/raw/master/AIROC_DFP/" vendor="Infineon" name="AIROC_DFP" version="1.2.0"/>
     <pdsc url="https://github.com/Infineon/cmsis-packs/raw/master/PSoC6_DFP/" vendor="Infineon" name="PSoC6_DFP" version="1.4.0"/>
-    <pdsc url="https://github.com/Infineon/cmsis-packs/raw/master/CAT1C_DFP/" vendor="Infineon" name="CAT1C_DFP" version="1.0.0"/>
-    <pdsc url="https://github.com/Infineon/cmsis-packs/raw/master/CAT2_DFP/" vendor="Infineon" name="CAT2_DFP" version="1.3.0"/>
-    <pdsc url="https://github.com/Infineon/cmsis-packs/raw/master/CAT1A_DFP/" vendor="Infineon" name="CAT1A_DFP" version="1.5.0"/>
   </pindex>
 </index>

--- a/README.md
+++ b/README.md
@@ -12,4 +12,11 @@ The following CMSIS DFP packs were moved from Cypress.pidx to Infineon.pidx at h
 * Infineon.CAT2_DFP
 * Infineon.CAT1A_DFP
 
-This repo is deprecated. Upcoming Infineon CMSIS pack releases will be uploaded to https://itools.infineon.com/cmsis_packs/, updating Infineon.pidx instead of Cypress.pidx.
+The following CMSIS DFP packs were marked as deprecated:
+
+* Cypress.PSoC6_DFP (replaced by Infineon.CAT1A_DFP)
+* Cypress.PSoC4_DFP (replaced by Infineon.CAT2_DFP)
+* Cypress.PMG1_DFP (replaced by Infineon.CAT2_DFP)
+* Infineon.PSoC6_DFP (replaced by Infineon.CAT1A_DFP)
+
+This repo is deprecated. Upcoming Infineon CMSIS pack releases will be uploaded to https://itools.infineon.com/cmsis_packs/, updating [Infineon.pidx](https://github.com/Infineon/cmsis_packs/blob/master/Infineon.pidx) instead of [Cypress.pidx](https://github.com/Infineon/cmsis-packs/blob/master/Cypress.pidx).

--- a/README.md
+++ b/README.md
@@ -2,3 +2,14 @@
 Device Family Packs for IDE support
 
 This repo hosts CMSIS DFPs for Cypress devices. Tools retrieve this file automatically when required, you do not need to clone or download this repository. 
+
+## 2024-11-06 update
+
+The following CMSIS DFP packs were moved from Cypress.pidx to Infineon.pidx at https://github.com/Infineon/cmsis_packs:
+
+* Infineon.AIROC_DFP
+* Infineon.CAT1C_DFP
+* Infineon.CAT2_DFP
+* Infineon.CAT1A_DFP
+
+This repo is deprecated. Upcoming Infineon CMSIS pack releases will be uploaded to https://itools.infineon.com/cmsis_packs/, updating Infineon.pidx instead of Cypress.pidx.


### PR DESCRIPTION
* Move active DFP packs to cmsis_packs/Infineon.pidx
* Pack files are now hosted at https://itools.infineon.com/cmsis_packs/
* Update pack base URL to https://github.com/Infineon
* Deprecate PSoC6_DFP/PSoC4_DFP/PMG1_DFP

See also https://github.com/Infineon/cmsis_packs/pull/4